### PR TITLE
Fix existing commands and add new tp and pos commands

### DIFF
--- a/DeveloperConsole/DeveloperConsole.cs
+++ b/DeveloperConsole/DeveloperConsole.cs
@@ -1,5 +1,5 @@
 ﻿using UnityEngine;
-using UnityEngine.SceneManagement;
+using Scene = UnityEngine.SceneManagement;
 
 namespace DeveloperConsole
 {
@@ -9,7 +9,7 @@ namespace DeveloperConsole
 
         public static void OnLoad()
         {
-            UnityEngine.Object.Instantiate(Resources.Load("uConsole"));
+            Object.Instantiate(Resources.Load("uConsole"));
             uConsole.m_Instance.m_Activate = KeyCode.F1;
             AddConsoleCommands();
         }
@@ -37,18 +37,18 @@ namespace DeveloperConsole
 
             uConsole.RegisterCommand("save", new uConsole.DebugCommand(() =>
             {
-                GameManager.SaveGameAndDisplayHUDMessage();
+                GameManager.m_PendingSave = true;
             }));
 
 
             uConsole.RegisterCommand("currentSceneName", new uConsole.DebugCommand(() =>
             {
-                Debug.Log(SceneManager.GetActiveScene().name);
+                Debug.Log(Scene.SceneManager.GetActiveScene().name);
             }));
 
             uConsole.RegisterCommand("currentSceneIndex", new uConsole.DebugCommand(() =>
             {
-                Debug.Log(SceneManager.GetActiveScene().buildIndex);
+                Debug.Log(Scene.SceneManager.GetActiveScene().buildIndex);
             }));
 
         }

--- a/DeveloperConsole/DeveloperConsole.cs
+++ b/DeveloperConsole/DeveloperConsole.cs
@@ -16,41 +16,34 @@ namespace DeveloperConsole
 
         private static void AddConsoleCommands()
         {
-            uConsole.RegisterCommand("load_scene", new uConsole.DebugCommand(() =>
-            {
-                var ind = uConsole.GetInt();
-                SceneManager.LoadScene(ind);
-            }));
+            uConsole.RegisterCommand("load_scene", LoadScene);
 
-            uConsole.RegisterCommand("fly", new uConsole.DebugCommand(() =>
-            {
-                bool fly = !FlyMode.m_Enabled;
-                if (uConsole.GetNumParameters() > 0 && uConsole.NextParameterIsBool())
-                    fly = uConsole.GetBool();
-                if (fly == FlyMode.m_Enabled)
-                    return;
-                if (fly)
-                    FlyMode.Enter();
-                else
-                    FlyMode.TeleportPlayerAndExit();
-            }));
+            uConsole.RegisterCommand("fly", Fly);
 
-            uConsole.RegisterCommand("save", new uConsole.DebugCommand(() =>
-            {
-                GameManager.m_PendingSave = true;
-            }));
+            uConsole.RegisterCommand("save", () => GameManager.m_PendingSave = true);
 
+            uConsole.RegisterCommand("currentSceneName", () => Debug.Log(Scene.SceneManager.GetActiveScene().name));
 
-            uConsole.RegisterCommand("currentSceneName", new uConsole.DebugCommand(() =>
-            {
-                Debug.Log(Scene.SceneManager.GetActiveScene().name);
-            }));
+            uConsole.RegisterCommand("currentSceneIndex", () => Debug.Log(Scene.SceneManager.GetActiveScene().buildIndex));
+        }
 
-            uConsole.RegisterCommand("currentSceneIndex", new uConsole.DebugCommand(() =>
-            {
-                Debug.Log(Scene.SceneManager.GetActiveScene().buildIndex);
-            }));
+        private static void LoadScene()
+        {
+            var ind = uConsole.GetInt();
+            SceneManager.LoadScene(ind);
+        }
 
+        private static void Fly()
+        {
+            bool fly = !FlyMode.m_Enabled;
+            if (uConsole.GetNumParameters() > 0 && uConsole.NextParameterIsBool())
+                fly = uConsole.GetBool();
+            if (fly == FlyMode.m_Enabled)
+                return;
+            if (fly)
+                FlyMode.Enter();
+            else
+                FlyMode.TeleportPlayerAndExit();
         }
     }
 }

--- a/DeveloperConsole/DeveloperConsole.cs
+++ b/DeveloperConsole/DeveloperConsole.cs
@@ -25,6 +25,10 @@ namespace DeveloperConsole
             uConsole.RegisterCommand("currentSceneName", () => Debug.Log(Scene.SceneManager.GetActiveScene().name));
 
             uConsole.RegisterCommand("currentSceneIndex", () => Debug.Log(Scene.SceneManager.GetActiveScene().buildIndex));
+
+            uConsole.RegisterCommand("pos", GetPosition);
+
+            uConsole.RegisterCommand("tp", Teleport);
         }
 
         private static void LoadScene()
@@ -44,6 +48,49 @@ namespace DeveloperConsole
                 FlyMode.Enter();
             else
                 FlyMode.TeleportPlayerAndExit();
+        }
+
+        private static void GetPosition()
+        {
+            Vector3 pos = GameManager.GetVpFPSPlayer().transform.position;
+            Debug.LogFormat("[{0:F2} / {1:F2} / {2:F2}]", pos.x, pos.y, pos.z);
+        }
+
+        private static void Teleport()
+        {
+            Vector3 target;
+
+            if (uConsole.GetNumParameters() < 2)
+            {
+                Debug.Log("Usage: tp x z    or    tp x y z.\nExample: tp 123 890");
+                return;
+            }
+            else if (uConsole.GetNumParameters() == 2)
+            {
+                float x = uConsole.GetFloat();
+                float z = uConsole.GetFloat();
+
+                Vector3 start = new Vector3(x, 10000f, z);
+                if (Physics.Raycast(start, Vector3.down, out RaycastHit raycastHit, float.PositiveInfinity, Utils.m_PhysicalCollisionLayerMask | 1048576 | 134217728))
+                {
+                    target = raycastHit.point + new Vector3(0, 0.01f, 0);
+                }
+                else
+                {
+                    target = new Vector3(x, 0, z);
+                }
+            }
+            else
+            {
+                float x = uConsole.GetFloat();
+                float y = uConsole.GetFloat();
+                float z = uConsole.GetFloat();
+                target = new Vector3(x, y, z);
+            }
+
+            Quaternion rot = GameManager.GetVpFPSCamera().transform.rotation;
+            GameManager.GetPlayerManagerComponent().TeleportPlayer(target, rot);
+            GameManager.GetPlayerManagerComponent().StickPlayerToGround();
         }
     }
 }

--- a/DeveloperConsole/DeveloperConsole.cs
+++ b/DeveloperConsole/DeveloperConsole.cs
@@ -22,9 +22,9 @@ namespace DeveloperConsole
 
             uConsole.RegisterCommand("save", () => GameManager.m_PendingSave = true);
 
-            uConsole.RegisterCommand("currentSceneName", () => Debug.Log(Scene.SceneManager.GetActiveScene().name));
+            uConsole.RegisterCommand("scene_name", () => Debug.Log(Scene.SceneManager.GetActiveScene().name));
 
-            uConsole.RegisterCommand("currentSceneIndex", () => Debug.Log(Scene.SceneManager.GetActiveScene().buildIndex));
+            uConsole.RegisterCommand("scene_index", () => Debug.Log(Scene.SceneManager.GetActiveScene().buildIndex));
 
             uConsole.RegisterCommand("pos", GetPosition);
 

--- a/DeveloperConsole/DeveloperConsole.csproj
+++ b/DeveloperConsole/DeveloperConsole.csproj
@@ -37,6 +37,7 @@
     <Reference Include="Harmony" />
     <Reference Include="System" />
     <Reference Include="UnityEngine.CoreModule" />
+    <Reference Include="UnityEngine.PhysicsModule" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DeveloperConsole.cs" />

--- a/DeveloperConsole/DeveloperConsole.csproj
+++ b/DeveloperConsole/DeveloperConsole.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DeveloperConsole</RootNamespace>
     <AssemblyName>DeveloperConsole</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>false</DebugSymbols>
@@ -20,6 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -28,42 +30,13 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Assembly-CSharp">
-      <HintPath>E:\Games\steamapps\common\TheLongDark\tld_Data\Managed\Assembly-CSharp.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Harmony">
-      <HintPath>E:\Games\steamapps\common\TheLongDark\tld_Data\Managed\Harmony.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>E:\Games\steamapps\common\TheLongDark\tld_Data\Managed\Newtonsoft.Json.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
+    <Reference Include="Assembly-CSharp" />
+    <Reference Include="Harmony" />
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-    <Reference Include="UnityEngine">
-      <HintPath>E:\Games\steamapps\common\TheLongDark\tld_Data\Managed\UnityEngine.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>E:\Games\steamapps\common\TheLongDark\tld_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>E:\Games\steamapps\common\TheLongDark\tld_Data\Managed\UnityEngine.UI.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
+    <Reference Include="UnityEngine.CoreModule" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DeveloperConsole.cs" />


### PR DESCRIPTION
- Fixed `save`, `currentSceneName` (now called `scene_name`), and `currentSceneIndex` (now called `scene_index`
- Added new `pos` command to get the current position
- Added new `tp` command to teleport
- Target .NET v3.5 as required by the version of mono that TLD uses
- Clean up dependencies